### PR TITLE
Vulnerabilities

### DIFF
--- a/src/foo.py
+++ b/src/foo.py
@@ -9,7 +9,8 @@ class Foo:
         bs = Blowfish.block_size
         key = b'An arbitrarily long key'
         iv = Random.new().read(bs)
-        cipher = Blowfish.new(key, Blowfish.MODE_CBC, iv)
+        cipher = Crypto.Cipher.AESh.MODE_CBC, iv)
+
 
         return cipher
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import foo
 
 def do_some_other_stuff():
     foo = 'bar'
-    cipher = A.new('tempkey')
+    cipher = Crypto.Cipher.AES
 
     f = foo.Foo()
 
@@ -15,9 +15,11 @@ def do_some_other_stuff():
 
 def main():
     print 'This is for test purposes only'
-    hash1 = hashlib.md5()
+    hash1 = hashlib.sha5125()
 
 
+
+Crypto.Hash.SHA512
     h = SHA.new()
     h.update(b'Hello')
     print h.hexdigest()


### PR DESCRIPTION
We found potential vulnerability risks in your dependencies and used functions.
                    Some vulnerabilities have been replaced by safe alternatives. 

# Vulnerable Functions 
*foo.py:12:17:* Crypto.Cipher.Blowfish.new
* Replacement: Crypto.Cipher.AES


*main.py:8:13:* Crypto.Cipher.ARC4.new
* Replacement: Crypto.Cipher.AES


*main.py:18:12:* hashlib.md5
* Replacement: hashlib.sha512


*main.py:21:8:* Crypto.Hash.SHA.new
* Replacement: Crypto.Hash.SHA512


# Vulnerable Dependencies 
Some versions of dependencies used in the project might pose security threads. Please make sure to inform users to use safe versions. 

| Dependency  | Vulnerable Versions | Reason | 
| --------------| -------------------- | ------- | 
|ansible|<1.2.3|ansible 1.2.3 includes local security fixes for predictable file locations for ControlPersist and retry file paths on shared machines on operating systems without kernel symlink/hardlink protections.|
|ansible|<1.5.4|ansible 1.5.4 includes a security fix for safe_eval, which further hardens the checking of the evaluation function.|
|ansible|<1.5.5|ansible 1.5.5 includes a security fix for vault, to ensure the umask is set to a restrictive mode before creating/editing vault files.|
|ansible|<1.6.4|ansible includes 1.6.4 security updates related to evaluation of untrusted remote inputs.|
|ansible|<1.6.6|ansible 1.6.6 includes security updates to further protect against the incorrect execution of untrusted data.|
|ansible|<1.6.7|ansible 1.6.7 contains two security fixes:  * Strip lookup calls out of inventory variables and clean unsafe data    returned from lookup plugins (CVE-2014-4966)  * Make sure vars don't insert extra parameters into module args and prevent    duplicate params from superseding previous params (CVE-2014-4967)|
|ansible|<1.7|ansible 1.7 contains two security fixes:- Prevent the use of lookups when using legacy " " syntax around variables and with_* loops.  - Remove relative paths in TAR-archived file names used by ansible-galaxy.|
|ansible|<1.7.1|ansible 1.7.1 contains a security fix to disallow specifying 'args:' as a string, which could allow the insertion of extra module parameters through variables.|
|ansible|<1.8.3|ansible 1.8.3 fixes a security bug related to the default permissions set on a temporary file created when using "ansible-vault view <filename>".|
|ansible|<1.9.2|Ansible before 1.9.2 does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.|
|ansible|<1.9.6|The create_script function in the lxc_container module in Ansible before 1.9.6-1 and 2.x before 2.0.2.0 allows local users to write to arbitrary files or gain privileges via a symlink attack on (1) /opt/.lxc-attach-script, (2) the archived container in the archive_path directory, or the (3) lxc-attach-script.log or (4) lxc-attach-script.err files in the temporary directory.|
|ansible|<2.0.2|The create_script function in the lxc_container module in Ansible before 1.9.6-1 and 2.x before 2.0.2.0 allows local users to write to arbitrary files or gain privileges via a symlink attack on (1) /opt/.lxc-attach-script, (2) the archived container in the archive_path directory, or the (3) lxc-attach-script.log or (4) lxc-attach-script.err files in the temporary directory.|
|ansible|<2.2.1|ansible before 2.2.1 is vulnerable to arbitrary code execution. An attacker with control over a client system being managed by Ansible and the ability to send facts back to the Ansible server could use this flaw to execute arbitrary code on the Ansible server as the user and group Ansible is running as.|
|ansible|<2.3.1|ansible before 2.3.1 is vulnerable to CVE-2017-7481 - data for lookup plugins used as variables was not being correctly marked as "unsafe".|


# Test Report 
No tests detected. 
 
 --- 
 
This tool was developed as part of a Software Engineering course. If you have feedback then please reply to this pull-request. Thank you!